### PR TITLE
Disable OpenSSL shared libraries for Android

### DIFF
--- a/patches/_reason_native_web_esy_openssl/files/esy_build.sh
+++ b/patches/_reason_native_web_esy_openssl/files/esy_build.sh
@@ -15,7 +15,9 @@ if [ "$ESY_TOOLCHAIN_SYSTEM" == "android" ]; then
     --prefix=$cur__install \
     --openssldir=$cur__install/ssl \
     android-$ESY_TOOLCHAIN_PROCESSOR \
-    -D__ANDROID_API__=$ANDROID_API
+    -D__ANDROID_API__=$ANDROID_API \
+    no-shared # TODO: analyze if this is a good idea
+
 elif [ "$ESY_TOOLCHAIN_SYSTEM" == "ios" ]; then
   if [ "$ESY_TOOLCHAIN_PROCESSOR" == "x86_64" ]; then
     export CROSS_TOP="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer"

--- a/patches/_reason_native_web_esy_openssl/files/esy_build.sh
+++ b/patches/_reason_native_web_esy_openssl/files/esy_build.sh
@@ -33,7 +33,10 @@ elif [ "$ESY_TOOLCHAIN_SYSTEM" == "ios" ]; then
     --openssldir=$cur__install/ssl \
     iphoneos-cross
 else
-  ./openssl/config --prefix=$cur__install --openssldir=$cur__install/ssl --cross-compile-prefix=${ESY_TOOLCHAIN_HOST}-;
+  ./openssl/config \
+    --prefix=$cur__install 
+    --openssldir=$cur__install/ssl \
+    --cross-compile-prefix=${ESY_TOOLCHAIN_HOST}-;
 fi
 
 make -j8


### PR DESCRIPTION
## Problem

To add a shared library on Android it should start with `lib` and end with `.so`, OpenSSL is generating libs on the following format `libssl.so.1.1` and `libcrypto.so.1.1`.

## Possible solution

We could do a `patchelf` and rename them, to something like `libssl.so` and `libcrypto.so`, but that would also required to ship both `.so` on the APK, which is not desirable.

## Choosen solution

Use the static version `libssl.a` and `libcrypto.a`, simplest way to use the static lib is to not have the shared one available, which is what this PR is doing.

## Issues

This PR is a workaround for #17