### PR TITLE
Build @opam/piaf for Android

### DIFF
--- a/patches/esy_openssl/files/esy_build.sh
+++ b/patches/esy_openssl/files/esy_build.sh
@@ -1,0 +1,42 @@
+#! /bin/sh
+
+set -e
+set -u
+
+export OCAMLFIND_TOOLCHAIN=$ESY_TOOLCHAIN
+if [ "$ESY_TOOLCHAIN_SYSTEM" == "android" ]; then
+  export ANDROID_NDK_HOME="$NDK_ROOT"
+  export PATH="$NDK_PREBUILT/bin:$PATH"
+
+  ## TODO: this API shouldn't be hardcoded
+  ANDROID_API="24"
+
+  ./Configure \
+    --prefix=$cur__install \
+    --openssldir=$cur__install/ssl \
+    android-$ESY_TOOLCHAIN_PROCESSOR \
+    -D__ANDROID_API__=$ANDROID_API \
+    no-shared # TODO: analyze if this is a good idea
+
+elif [ "$ESY_TOOLCHAIN_SYSTEM" == "ios" ]; then
+  if [ "$ESY_TOOLCHAIN_PROCESSOR" == "x86_64" ]; then
+    export CROSS_TOP="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer"
+    export CROSS_SDK="iPhoneSimulator.sdk"
+  else
+    export CROSS_TOP="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer"
+    export CROSS_SDK="iPhoneOS.sdk"
+  fi
+  export CC="$ESY_TOOLCHAIN_CC"
+
+  ./Configure \
+    --prefix=$cur__install \
+    --openssldir=$cur__install/ssl \
+    iphoneos-cross
+else
+  ./config \
+    --prefix=$cur__install 
+    --openssldir=$cur__install/ssl \
+    --cross-compile-prefix=${ESY_TOOLCHAIN_HOST}-;
+fi
+
+make -j8

--- a/patches/esy_openssl/package.json
+++ b/patches/esy_openssl/package.json
@@ -1,0 +1,5 @@
+{
+  "build": [
+    ["bash", "esy_build.sh"]
+  ]
+}


### PR DESCRIPTION
### Problem

With `@reason-native-web/piaf` being published in the OPAM repository, we need to apply the same patches of `@reason-native-web/esy-openssl` in the `esy/openssl` package as well

### This PR

This PR implements the same workaround of #16 and disables Android's OpenSSL shared libraries for `esy/openssl`
