### PR TITLE
installer: only install if a file exists

### DIFF
--- a/generate-installer/src/Installer.re
+++ b/generate-installer/src/Installer.re
@@ -191,10 +191,11 @@ module Make =
                  ? Filename.concat(pwd, from) : from;
              };
              let.await exists = Lwt_unix.file_exists(from);
-             switch (optional, exists) {
-             | (true, false) => await()
+             switch (exists) {
+             | false => await()
              // TODO: should I ensure the file exists even when not optional?
-             | _ =>
+             // about above, seems so for esy
+             | true =>
                let+await _ = Lib.exec("ln -sfn " ++ from ++ " " ++ to_);
                ();
              };


### PR DESCRIPTION
This is a workaround to esy 0.6.8, previously we just installed all the `.install` files present, making a symlink. This includes missing files

This was okay, but as something changed on esy, this invalid symlinks lead to esy failing to rewrite the path, overall failing to install the packages, locally you could still run the command again, but on CIs that was not the case

Mostly fixes #23 