### PR TITLE
Linux ARMv6

### DIFF
--- a/.github/workflows/hello-reason.yml
+++ b/.github/workflows/hello-reason.yml
@@ -12,7 +12,11 @@ jobs:
 
     strategy:
       matrix:
+        word_size: [64]
         system: [ubuntu, macos, macos-arm64]
+        include:
+          - system: ubuntu
+            word_size: 32
 
     runs-on: ${{ matrix.system }}-latest
 
@@ -27,7 +31,8 @@ jobs:
         if: ${{ matrix.system != 'macos-arm64' }}
         run: npm install -g esy
 
-      - name: Create esy wrapper
+      - name: Create esy wrapper 64bits
+        if: ${{ matrix.word_size == 64 }}
         run: |
           echo '{
             "source": "./package.json",
@@ -37,17 +42,52 @@ jobs:
               }
             }
           }' > generate.json
+
+      - name: Create esy wrapper 32bits
+        if: ${{ matrix.word_size == 32 }}
+        run: |
+          sudo apt-get install gcc-multilib
+          echo '{
+            "source": "./package.json",
+            "override": {
+              "dependencies": {
+                "reason-mobile": "github:'"${GITHUB_REPOSITORY}"':generate.json#'"${GITHUB_SHA}"'"
+              },
+              "resolutions": {
+                "ocaml": {
+                  "source": "esy-ocaml/ocaml#dd66cad318e04c7f2c753f8ce2fd8851e975f89a",
+                  "override": {
+                    "build": [
+                      [
+                        "./esy-configure",
+                        "--prefix", "$cur__install",
+                        "--build=x86_64-pc-linux-gnu",
+                        "--host=i386-linux",
+                        "CC=gcc -m32",
+                        "AS=as --32",
+                        "ASPP=gcc -m32 -c",
+                        "PARTIALLD=ld -r -melf_i386"
+                      ],
+                      "./esy-build"
+                    ]
+                  }
+                }
+              }
+            }
+          }' > generate.json
+
       - uses: esy/github-action@master
         with:
           working-directory: examples/hello-reason
           manifest: ./generate.json
-          cache-key: ${{ hashFiles('esy.lock/index.json') }}
+          cache-key: ${{ hashFiles('esy.lock/index.json') }}-${{ matrix.word_size }}
 
   cross-compile:
     needs: native
     strategy:
       fail-fast: false
       matrix:
+        word_size: [64]
         system: [ubuntu, macos, macos-arm64]
         target:
           [
@@ -58,8 +98,12 @@ jobs:
             ios.simulator.x86_64,
             linux.musl.arm64,
             linux.musl.x86_64,
-            macos.arm64
+            macos.arm64,
           ]
+        include:
+          - system: ubuntu
+            word_size: 32
+            target: linux.musl.armv6
         exclude:
           - system: ubuntu
             target: ios.arm64
@@ -95,7 +139,8 @@ jobs:
         if: ${{ matrix.system != 'macos-arm64' }}
         run: npm install -g esy
 
-      - name: Create esy wrapper
+      - name: Create esy wrapper 64bits
+        if: ${{ matrix.word_size == 64 }}
         run: |
           echo '{
             "source": "./package.json",
@@ -105,11 +150,45 @@ jobs:
               }
             }
           }' > generate.json
+
+      - name: Create esy wrapper 32bits
+        if: ${{ matrix.word_size == 32 }}
+        run: |
+          sudo apt-get install gcc-multilib
+          echo '{
+            "source": "./package.json",
+            "override": {
+              "dependencies": {
+                "reason-mobile": "github:'"${GITHUB_REPOSITORY}"':generate.json#'"${GITHUB_SHA}"'"
+              },
+              "resolutions": {
+                "ocaml": {
+                  "source": "esy-ocaml/ocaml#dd66cad318e04c7f2c753f8ce2fd8851e975f89a",
+                  "override": {
+                    "build": [
+                      [
+                        "./esy-configure",
+                        "--prefix", "$cur__install",
+                        "--build=x86_64-pc-linux-gnu",
+                        "--host=i386-linux",
+                        "CC=gcc -m32",
+                        "AS=as --32",
+                        "ASPP=gcc -m32 -c",
+                        "PARTIALLD=ld -r -melf_i386"
+                      ],
+                      "./esy-build"
+                    ]
+                  }
+                }
+              }
+            }
+          }' > generate.json
+
       - uses: esy/github-action@master
         with:
           working-directory: examples/hello-reason
           manifest: ./generate.json
-          cache-key: ${{ hashFiles('esy.lock/index.json') }}
+          cache-key: ${{ hashFiles('esy.lock/index.json') }}-${{ matrix.word_size == 64 }}
 
       - name: Generate wrapper
         run: esy @generate generate ${{ matrix.target }}

--- a/sysroot/linux.musl.armv6/package.json
+++ b/sysroot/linux.musl.armv6/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@_linux.musl.armv6/sysroot",
+  "dependencies": {
+    "sysroot.tools": "*"
+  },
+  "esy": {
+    "build": "sh setup.sh",
+    "exportedEnv": {
+      "ESY_TOOLCHAIN": {
+        "val": "linux.musl.armv6",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_SYSTEM": {
+        "val": "linux",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_PROCESSOR": {
+        "val": "armv6",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_SYSROOT": {
+        "val": "/",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_CMAKE": {
+        "val": "-DCMAKE_TOOLCHAIN_FILE=#{self.install}/toolchain.cmake",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_BUILD": {
+        "val": "x86_64-pc-linux-gnu",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_HOST": {
+        "val": "armv6-unknown-linux-musleabihf",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_FULL_HOST": {
+        "val": "armv6-unknown-linux-musleabihf",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_CC": {
+        "val": "armv6-unknown-linux-musleabihf-gcc",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_CXX": {
+        "val": "armv6-unknown-linux-musleabihf-g++",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_AS": {
+        "val": "armv6-unknown-linux-musleabihf-as",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_AR": {
+        "val": "armv6-unknown-linux-musleabihf-ar",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_RANLIB": {
+        "val": "armv6-unknown-linux-musleabihf-ranlib",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_ASPP": {
+        "val": "armv6-unknown-linux-musleabihf-gcc -c",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_LD": {
+        "val": "armv6-unknown-linux-musleabihf-ld",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_PARTIALLD": {
+        "val": "armv6-unknown-linux-musleabihf-ld -r",
+        "scope": "global"
+      }
+    }
+  }
+}

--- a/sysroot/linux.musl.armv6/setup.sh
+++ b/sysroot/linux.musl.armv6/setup.sh
@@ -1,0 +1,51 @@
+#! /bin/sh
+
+set -e
+set -u
+
+## Download
+
+CC_SOURCE="http://musl.cc/armv6-linux-musleabihf-cross.tgz"
+CC_TARGET="$cur__target_dir/musl.armv6.tgz"
+
+pushd $cur__install
+curl -o $CC_TARGET $CC_SOURCE
+tar xvp --strip-components=1 -f $CC_TARGET
+popd
+
+export PATH=$cur__bin:$PATH
+
+## Setup
+
+ARCH="armv6"
+TOOLCHAIN="linux.musl.armv6"
+BASE_TRIPLE="armv6-linux-musleabihf"
+TARGET_TRIPLE="armv6-unknown-linux-musleabihf"
+
+gen_tools () {
+  TOOL_NAME="$1"
+  HOST="$(which $TOOL_NAME)"
+  TARGET="$(which $BASE_TRIPLE-$TOOL_NAME || which $TOOL_NAME)"
+
+  sysroot-gen-tools "$TOOLCHAIN" "$TARGET_TRIPLE" "$TOOL_NAME" "$TARGET" "$HOST"
+}
+
+gen_tools ar
+gen_tools as
+gen_tools gcc
+gen_tools g++
+gen_tools ld
+gen_tools nm
+gen_tools objdump
+gen_tools ranlib
+gen_tools strip
+
+cat > $cur__install/toolchain.cmake <<EOF
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR $ARCH)
+
+set(CMAKE_AR $TARGET_TRIPLE-ar)
+set(CMAKE_RANLIB $TARGET_TRIPLE-ranlib)
+set(CMAKE_C_COMPILER $TARGET_TRIPLE-gcc)
+set(CMAKE_CXX_COMPILER $TARGET_TRIPLE-g++)
+EOF


### PR DESCRIPTION
This is the target needed to both the Raspberry Pi Zero and Pico.

## How to try?

To try it you can pin to the branch and add a resolution with an OCaml 32bits compiler, so this should only works on Linux

```sh
## pin the generate
esy add -D generate@EduardoRFS/reason-mobile:generate.json#02663b4484dbf13ea08451edbdf193b8ce955728
```

```json
{
  "resolutions": {
    "ocaml": {
      "source": "esy-ocaml/ocaml#dd66cad318e04c7f2c753f8ce2fd8851e975f89a",
      "override": {
        "build": [
          [
            "./esy-configure",
            "--prefix", "$cur__install",
            "--build=x86_64-pc-linux-gnu",
            "--host=i386-linux",
            "CC=gcc -m32",
            "AS=as --32",
            "ASPP=gcc -m32 -c",
            "PARTIALLD=ld -r -melf_i386"
          ],
          "./esy-build"
        ]
      }
    }
  }
}
```

## Why the resolution?

OCaml cannot do cross-compiling across different word sizes, like 64 bits -> 32 bits, so we need to workaround it by using an OCaml for x86_32. As macOS doesn't support 32bits modes anymore, this will not work there.