### PR TITLE
sysroot: add android.armv7a

### DIFF
--- a/.github/workflows/hello-reason.yml
+++ b/.github/workflows/hello-reason.yml
@@ -107,6 +107,9 @@ jobs:
           - system: ubuntu
             word_size: 32
             target: linux.musl.armv7l
+          - system: ubuntu
+            word_size: 32
+            target: android.armv7a
         exclude:
           - system: ubuntu
             target: ios.arm64

--- a/sysroot/android.armv7a/package.json
+++ b/sysroot/android.armv7a/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@_android.armv7a/sysroot",
+  "dependencies": {
+    "sysroot.tools": "*",
+    "@_android/ndk": "*"
+  },
+  "esy": {
+    "build": [
+      [
+        "sh",
+        "setup.sh",
+        "#{@_android/ndk.install}/ndk/toolchains/llvm/prebuilt/#{os}-x86_64/bin"
+      ]
+    ],
+    "exportedEnv": {
+      "ESY_TOOLCHAIN": {
+        "val": "android.armv7a",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_SYSTEM": {
+        "val": "android",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_PROCESSOR": {
+        "val": "armv7a",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_SYSROOT": {
+        "val": "#{@_android/ndk.install}/ndk",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_CMAKE": {
+        "val": "-DCMAKE_TOOLCHAIN_FILE=#{self.install}/toolchain.cmake",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_BUILD": {
+        "val": "x86_64-pc-linux-gnu",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_HOST": {
+        "val": "armv7a-unknown-linux-androideabi",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_FULL_HOST": {
+        "val": "armv7a-linux-androideabi24",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_CC": {
+        "val": "armv7a-linux-androideabi24-clang",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_CXX": {
+        "val": "armv7a-linux-androideabi24-clang++",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_AS": {
+        "val": "armv7a-linux-androideabi24-as",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_AR": {
+        "val": "armv7a-linux-androideabi24-ar",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_RANLIB": {
+        "val": "armv7a-linux-androideabi24-ranlib",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_ASPP": {
+        "val": "armv7a-linux-androideabi24-clang -c",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_LD": {
+        "val": "armv7a-linux-androideabi24-ld",
+        "scope": "global"
+      },
+      "ESY_TOOLCHAIN_PARTIALLD": {
+        "val": "armv7a-linux-androideabi24-ld -r",
+        "scope": "global"
+      }
+    }
+  }
+}

--- a/sysroot/android.armv7a/setup.sh
+++ b/sysroot/android.armv7a/setup.sh
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+set -e
+set -u
+
+export PATH="$PATH:$1"
+
+TOOLCHAIN="android.armv7a"
+BASE_TRIPLE="arm-linux-androideabi"
+TARGET_TRIPLE="armv7a-linux-androideabi24"
+
+gen_tools () {
+  TOOL_NAME="$1"
+  HOST="$(which $TOOL_NAME)"
+  TARGET="$(which $TARGET_TRIPLE-$TOOL_NAME || which $BASE_TRIPLE-$TOOL_NAME)"
+
+  sysroot-gen-tools "$TOOLCHAIN" "$TARGET_TRIPLE" "$TOOL_NAME" "$TARGET" "$HOST"
+}
+
+gen_tools ar
+gen_tools as
+gen_tools clang
+gen_tools clang++
+gen_tools ld
+gen_tools nm
+gen_tools objdump
+gen_tools ranlib
+gen_tools strip
+
+cat > $cur__install/toolchain.cmake <<EOF
+set(ANDROID_ABI armeabi-v7a)
+set(ANDROID_NATIVE_API_LEVEL 24) # API level
+
+include($NDK_ROOT/build/cmake/android.toolchain.cmake)
+EOF


### PR DESCRIPTION
## How to try?

To try it you can pin to the branch and add a resolution with an OCaml 32bits compiler, so this should only works on Linux for now

```sh
## pin the generate
esy add -D generate@EduardoRFS/reason-mobile:generate.json#12fe5443d1e636450c197e50cc259b9b23822d0c
```

```json
{
  "resolutions": {
    "ocaml": {
      "source": "esy-ocaml/ocaml#dd66cad318e04c7f2c753f8ce2fd8851e975f89a",
      "override": {
        "build": [
          [
            "./esy-configure",
            "--prefix", "$cur__install",
            "--build=x86_64-pc-linux-gnu",
            "--host=i386-linux",
            "CC=gcc -m32",
            "AS=as --32",
            "ASPP=gcc -m32 -c",
            "PARTIALLD=ld -r -melf_i386"
          ],
          "./esy-build"
        ]
      }
    }
  }
}
```

## Why the resolution?

OCaml cannot do cross-compiling across different word sizes, like 64 bits -> 32 bits, so we need to workaround it by using an OCaml for x86_32. As macOS doesn't support 32bits modes anymore, this will not work there.