### PR TITLE
fix patch for musl and android on arm32

### DIFF
--- a/patches/ocaml/files/arm-additional-eabi.patch
+++ b/patches/ocaml/files/arm-additional-eabi.patch
@@ -1,8 +1,54 @@
 diff --git a/configure b/configure
-index e2ea57c81..008680329 100755
-Binary files a/configure and b/configure differ
+index e2ea57c81..dafe2f1ce 100755
+--- a/configure
++++ b/configure
+@@ -13885,19 +13885,19 @@ else
+ fi; system=elf ;; #(
+   s390x*-*-linux*) :
+     arch=s390x; model=z10; system=elf ;; #(
+-  armv6*-*-linux-gnueabihf) :
++  armv6*-*-linux-*eabihf*) :
+     arch=arm; model=armv6; system=linux_eabihf ;; #(
+-  armv7*-*-linux-gnueabihf) :
++  armv7*-*-linux-*eabihf*) :
+     arch=arm; model=armv7; system=linux_eabihf ;; #(
+-  armv8*-*-linux-gnueabihf) :
++  armv8*-*-linux-*abihf*) :
+     arch=arm; model=armv8; system=linux_eabihf ;; #(
+-  armv8*-*-linux-gnueabi) :
++  armv8*-*-linux-*eabi*) :
+     arch=arm; model=armv8; system=linux_eabi ;; #(
+-  armv7*-*-linux-gnueabi) :
++  armv7*-*-linux-*eabi*) :
+     arch=arm; model=armv7; system=linux_eabi ;; #(
+-  armv6t2*-*-linux-gnueabi) :
++  armv6t2*-*-linux-*eabi*) :
+     arch=arm; model=armv6t2; system=linux_eabi ;; #(
+-  armv6*-*-linux-gnueabi) :
++  armv6*-*-linux-*eabi*) :
+     arch=arm; model=armv6; system=linux_eabi ;; #(
+   armv6*-*-freebsd*) :
+     arch=arm; model=armv6; system=freebsd ;; #(
+@@ -13905,13 +13905,13 @@ fi; system=elf ;; #(
+     arch=arm; model=armv6; system=netbsd ;; #(
+   earmv7*-*-netbsd*) :
+     arch=arm; model=armv7; system=netbsd ;; #(
+-  armv5te*-*-linux-gnueabi) :
++  armv5te*-*-linux-*eabi*) :
+     arch=arm; model=armv5te; system=linux_eabi ;; #(
+-  armv5*-*-linux-gnueabi) :
++  armv5*-*-linux-*eabi*) :
+     arch=arm; model=armv5; system=linux_eabi ;; #(
+-  arm*-*-linux-gnueabihf) :
++  arm*-*-linux-*eabihf*) :
+     arch=arm; system=linux_eabihf ;; #(
+-  arm*-*-linux-gnueabi) :
++  arm*-*-linux-*eabi*) :
+     arch=arm; system=linux_eabi ;; #(
+   arm*-*-openbsd*) :
+     arch=arm; system=bsd ;; #(
 diff --git a/configure.ac b/configure.ac
-index 656ffe20c..61179078c 100644
+index 656ffe20c..a570a015f 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -955,19 +955,19 @@ AS_CASE([$host],
@@ -10,25 +56,25 @@ index 656ffe20c..61179078c 100644
    [[s390x*-*-linux*]],
      [arch=s390x; model=z10; system=elf],
 -  [armv6*-*-linux-gnueabihf],
-+  [armv6*-*-linux-*eabihf],
++  [armv6*-*-linux-*eabihf*],
      [arch=arm; model=armv6; system=linux_eabihf],
 -  [armv7*-*-linux-gnueabihf],
-+  [armv7*-*-linux-*eabihf],
++  [armv7*-*-linux-*eabihf*],
      [arch=arm; model=armv7; system=linux_eabihf],
 -  [armv8*-*-linux-gnueabihf],
-+  [armv8*-*-linux-*abihf],
++  [armv8*-*-linux-*abihf*],
      [arch=arm; model=armv8; system=linux_eabihf],
 -  [armv8*-*-linux-gnueabi],
-+  [armv8*-*-linux-*eabi],
++  [armv8*-*-linux-*eabi*],
      [arch=arm; model=armv8; system=linux_eabi],
 -  [armv7*-*-linux-gnueabi],
-+  [armv7*-*-linux-*eabi],
++  [armv7*-*-linux-*eabi*],
      [arch=arm; model=armv7; system=linux_eabi],
 -  [armv6t2*-*-linux-gnueabi],
-+  [armv6t2*-*-linux-*eabi],
++  [armv6t2*-*-linux-*eabi*],
      [arch=arm; model=armv6t2; system=linux_eabi],
 -  [armv6*-*-linux-gnueabi],
-+  [armv6*-*-linux-*eabi],
++  [armv6*-*-linux-*eabi*],
      [arch=arm; model=armv6; system=linux_eabi],
    [armv6*-*-freebsd*],
      [arch=arm; model=armv6; system=freebsd],
@@ -37,16 +83,16 @@ index 656ffe20c..61179078c 100644
    [earmv7*-*-netbsd*],
      [arch=arm; model=armv7; system=netbsd],
 -  [armv5te*-*-linux-gnueabi],
-+  [armv5te*-*-linux-*eabi],
++  [armv5te*-*-linux-*eabi*],
      [arch=arm; model=armv5te; system=linux_eabi],
 -  [armv5*-*-linux-gnueabi],
-+  [armv5*-*-linux-*eabi],
++  [armv5*-*-linux-*eabi*],
      [arch=arm; model=armv5; system=linux_eabi],
 -  [arm*-*-linux-gnueabihf],
-+  [arm*-*-linux-*eabihf],
++  [arm*-*-linux-*eabihf*],
      [arch=arm; system=linux_eabihf],
 -  [arm*-*-linux-gnueabi],
-+  [arm*-*-linux-*eabi],
++  [arm*-*-linux-*eabi*],
      [arch=arm; system=linux_eabi],
    [arm*-*-openbsd*],
      [arch=arm; system=bsd],


### PR DESCRIPTION
This happened because, `configure` is ignored on git diff and I was negligent and didn't wait for it to finish building when migrating to the new OCaml 4.12.

And android also needs * after eabi, because it can be `androideabi24`

https://github.com/ocaml/ocaml/blob/trunk/.gitattributes#L34